### PR TITLE
Finland uses 'ALV' as the abbreviation, not AVL

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -106,7 +106,7 @@
         "FI": {
             "country": "Finland",
             "vat_name": "Arvonlisävero",
-            "vat_abbr": "AVL",
+            "vat_abbr": "ALV",
             "standard_rate": 24.00,
             "reduced_rate": 14.00,
             "reduced_rate_alt": 10.00,


### PR DESCRIPTION
https://www.ytj.fi/en/index/vatnumber.html