### PR TITLE
Updated 2023 rates for Luxembourg

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -167,9 +167,9 @@
             "country": "Luxembourg",
             "vat_name": "Taxe sur la valeur ajoutée",
             "vat_abbr": "TVA",
-            "standard_rate": 17.00,
-            "reduced_rate": 14.00,
-            "reduced_rate_alt": 8.00,
+            "standard_rate": 16.00,
+            "reduced_rate": 13.00,
+            "reduced_rate_alt": 7.00,
             "super_reduced_rate": 3.00,
             "parking_rate": 12.00
         },


### PR DESCRIPTION
Luxembourg introduced a VAT reduction for the year 2023.

See https://gouvernement.lu/en/actualites/toutes_actualites/communiques/2022/12-decembre/31-nouveautes-2023.html and https://pfi.public.lu/fr/professionnel/tva/taxe-valeur-ajoutee/taux-nationaux-applicables.html for more details.