### PR TITLE
Update for raised VAT rate in Finland

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -107,7 +107,7 @@
             "country": "Finland",
             "vat_name": "Arvonlisävero",
             "vat_abbr": "ALV",
-            "standard_rate": 24.00,
+            "standard_rate": 25.50,
             "reduced_rate": 14.00,
             "reduced_rate_alt": 10.00,
             "super_reduced_rate": false,


### PR DESCRIPTION
Finland raised ALV to 25,5% on 1 September 2024.

Thanks!