### PR TITLE
TypeScript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   "bugs": {
     "url": "github.com/benbucksch/eu-vat-rates/issues"
   },
+  "types": "rates.d.ts",
   "license": "MIT"
 }

--- a/rates.d.ts
+++ b/rates.d.ts
@@ -1,0 +1,21 @@
+declare namespace euVatRates {
+    export interface EuVatRates {
+        last_updated: string;
+        disclaimer: string;
+        source: string;
+        rates: Record<string, CountryRate>;
+    }
+    
+    export interface CountryRate {
+        country: string;
+        vat_name: string;
+        vat_abbr: string;
+        standard_rate: number;
+        reduced_rate: boolean | number;
+        reduced_rate_alt: boolean | number;
+        super_reduced_rate: boolean | number;
+        parking_rate: boolean | number;
+    }
+}
+declare const euVatRates: euVatRates.EuVatRates;
+export = euVatRates;


### PR DESCRIPTION
Thank you for maintaining this!

This PR just adds TypeScript definitions for the JSON file, so it can be cleanly used like:

```typescript
import rates from 'eu-vat-rates' with { type: 'json' };
console.log(rates.rates.LV);
```